### PR TITLE
Remark/Rehype plugins

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,6 +8,9 @@ export default /** @type {import('astro').AstroUserConfig} */ ({
   base: "/trials-of-slavery/",
   trailingSlash: "always",
   integrations: [],
+  markdown: {
+    remarkPlugins: ["remark-gfm", "remark-supersub"],
+  },
   vite: {
     ssr: { external: ["neat-csv"] },
     optimizeDeps: { exclude: ["neat-csv"] },

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,8 @@
 // Full Astro Configuration API Documentation:
 // https://docs.astro.build/reference/configuration-reference
 
+import rehypeTrialsGlossary from "./lib/rehype-trials-glossary.mjs";
+
 // @ts-check
 export default /** @type {import('astro').AstroUserConfig} */ ({
   // Comment out "renderers: []" to enable Astro's default component support.
@@ -10,6 +12,7 @@ export default /** @type {import('astro').AstroUserConfig} */ ({
   integrations: [],
   markdown: {
     remarkPlugins: ["remark-gfm", "remark-supersub"],
+    rehypePlugins: [rehypeTrialsGlossary],
   },
   vite: {
     ssr: { external: ["neat-csv"] },

--- a/lib/rehype-trials-glossary.mjs
+++ b/lib/rehype-trials-glossary.mjs
@@ -50,7 +50,7 @@ const glossNodes = (term, gloss) => {
 const RehypeTrialsGlossary = (options) => {
   return (tree) => {
     visit(tree, "text", (node, index, parent) => {
-      if (!node.marked) {
+      if (parent.type == "element" && parent.tagName == "em" && !node.marked) {
         if (node.value in glossary) {
           parent.children = glossNodes(node.value, glossary[node.value]);
         }

--- a/lib/rehype-trials-glossary.mjs
+++ b/lib/rehype-trials-glossary.mjs
@@ -1,0 +1,62 @@
+import { visit } from "unist-util-visit";
+
+const glossary = {
+  heemraden:
+    "In the Netherlands, and also in Cape Colony until the 19th century, a member of a council to assist a local magistrate in the government of rural districts.",
+  baas: "An employer, a boss. Frequently as a form of address.",
+};
+
+const glossNodes = (term, gloss) => {
+  return [
+    {
+      type: "element",
+      tagName: "span",
+      properties: { className: "glossary" },
+      children: [
+        {
+          type: "text",
+          value: term,
+          marked: true,
+        },
+      ],
+    },
+    {
+      type: "element",
+      tagName: "span",
+      properties: { className: "gloss", role: "tooltip" },
+      children: [
+        {
+          type: "element",
+          tagName: "span",
+          properties: { className: "header" },
+          children: [
+            {
+              type: "text",
+              value: term,
+              marked: true,
+            },
+          ],
+        },
+        {
+          type: "text",
+          value: gloss,
+          marked: true,
+        },
+      ],
+    },
+  ];
+};
+
+const RehypeTrialsGlossary = (options) => {
+  return (tree) => {
+    visit(tree, "text", (node, index, parent) => {
+      if (!node.marked) {
+        if (node.value in glossary) {
+          parent.children = glossNodes(node.value, glossary[node.value]);
+        }
+      }
+    });
+  };
+};
+
+export default RehypeTrialsGlossary;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "autoprefixer": "^10.4.7",
     "postcss-custom-media": "^8.0.0",
     "postcss-nested": "^5.0.6",
-    "prettier-plugin-astro": "^0.0.12"
+    "prettier-plugin-astro": "^0.0.12",
+    "remark-supersub": "^1.0.0"
   },
   "dependencies": {
     "@floating-ui/dom": "^0.5.0",

--- a/src/documents/01_Dutch.md
+++ b/src/documents/01_Dutch.md
@@ -1,6 +1,6 @@
 **1/STB 3/8** Criminele Verklaringen, 1702-1749, unpaginated.
 
-<p>Op Saturdag, den 29<sup>e</sup> Augustus <em>anno</em> 1705.</p>
+Op Saturdag, den 29^e^ Augustus *anno* 1705.
 
 Examen gedaan door den edele landdrost Johannes Starrenburg ten overstaan van den heemraaden Guilliam du Toit en Ferdinandus Appel wegens de slaav van den landbouwer Arij van Wijk, genaamt Cinna, dewelke ’t naar volgende belijd:
 

--- a/src/glossary.mjs
+++ b/src/glossary.mjs
@@ -2,12 +2,6 @@ import { computePosition, flip, shift, offset } from "@floating-ui/dom";
 
 const documents = document.querySelectorAll(".document .translation");
 
-const glossary = {
-  heemraden:
-    "In the Netherlands, and also in Cape Colony until the 19th century, a member of a council to assist a local magistrate in the government of rural districts.",
-  baas: "An employer, a boss. Frequently as a form of address.",
-};
-
 const showGloss = (event) => {
   const termSpan = event.target;
   const glossSpan = termSpan.nextElementSibling;
@@ -40,15 +34,7 @@ const update = (termSpan, glossSpan) => {
   });
 };
 
-const markupDoc = (doc) => {
-  Object.keys(glossary).forEach((term) => {
-    doc.innerHTML = doc.innerHTML.replace(
-      new RegExp(term, "g"),
-      `<span class="glossary" aria-describedby="tooltip">${term}</span>
-       <span role="tooltip" class="gloss"><span class="header">${term}</span>${glossary[term]}</span>`,
-    );
-  });
-
+const addGlossaryEvents = (doc) => {
   doc.querySelectorAll(".glossary").forEach((termSpan) => {
     eventMap.forEach(([event, listener]) => {
       termSpan.addEventListener(event, listener);
@@ -56,4 +42,4 @@ const markupDoc = (doc) => {
   });
 };
 
-documents.forEach((doc) => markupDoc(doc));
+documents.forEach((doc) => addGlossaryEvents(doc));

--- a/yarn.lock
+++ b/yarn.lock
@@ -3415,6 +3415,13 @@ remark-smartypants@^2.0.0:
     retext-smartypants "^5.1.0"
     unist-util-visit "^4.1.0"
 
+remark-supersub@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/remark-supersub/-/remark-supersub-1.0.0.tgz#b2009884781961a37990f5581360cbe0e1632ab1"
+  integrity sha512-3SYsphMqpAWbr8AZozdcypozinl/lly3e7BEwPG3YT5J9uZQaDcELBF6/sr/OZoAlFxy2nhNFWSrZBu/ZPRT3Q==
+  dependencies:
+    unist-util-visit "^4.0.0"
+
 resolve@^1.10.0, resolve@^1.17.0, resolve@^1.22.0:
   version "1.22.0"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz"


### PR DESCRIPTION
This PR adds the `remark-supersub` plugin that provides support for pandoc-style superscripts, and a custom hand-written plugin to mark up terms (in `<em/>` tags) from a glossary.  I have a strong suspicion that Astro's markdown pipeline isn't going to be flexible enough to support a plugin to fix the footnotes issue, though, so it seems likely I'll need to re-implement the entire pipeline :(